### PR TITLE
chore: update default GET_TOKENS_INFO_URL during development

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -60,9 +60,7 @@ export function getConfig(): Config {
   const developmentSchema = sharedSchema.extend({
     GET_TOKENS_INFO_URL: z
       .string()
-      .default(
-        'https://blockchain-api-dot-celo-mobile-mainnet.appspot.com/tokensInfo',
-      ),
+      .default('https://api.mainnet.valora.xyz/getTokensInfoWithPrices'),
     GOOGLE_CLOUD_PROJECT: z.string().default('dev-project'),
     POSITION_IDS: z
       .string()


### PR DESCRIPTION
Quick follow up from https://github.com/mobilestack-xyz/hooks/pull/649