### PR TITLE
fix: valora app version check for Aave positions

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "i18next-fs-backend": "^2.6.0",
     "i18next-http-middleware": "^3.7.0",
     "lru-cache": "^11.0.2",
+    "semver": "^7.6.3",
     "viem": "^2.21.53",
     "zod": "^3.23.8"
   },

--- a/src/api/index.test.ts
+++ b/src/api/index.test.ts
@@ -12,7 +12,7 @@ import { getConfig } from '../config'
 
 jest.mock('../config')
 jest.mocked(getConfig).mockReturnValue({
-  POSITION_IDS: [],
+  POSITION_IDS: ['uniswap', 'aave', 'curve'],
   GET_TOKENS_INFO_URL: 'https://valoraapp.com/mock-endpoint',
   GOOGLE_CLOUD_PROJECT: 'dev-project',
   SHORTCUT_IDS: [],
@@ -281,6 +281,10 @@ jest.mocked(getShortcuts).mockResolvedValue(TEST_SHORTCUTS)
 
 const WALLET_ADDRESS = '0x0000000000000000000000000000000000007e57'
 
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
 describe('GET /getPositions', () => {
   it('returns balances for celo', async () => {
     const server = getTestServer('hooks-api')
@@ -322,6 +326,37 @@ describe('GET /getPositions', () => {
       data: TEST_POSITIONS_CELO,
     })
   })
+
+  for (const [userAgent, shouldIncludeAave] of [
+    ['Valora/1.90.0', true],
+    ['Valora/1.100.0', true],
+    ['Valora/1.89.9', false],
+    ['Valora/1.89.10', false],
+    ['SomeOtherApp/1.90.0', true],
+    [undefined, true],
+  ] as const) {
+    it(`returns positions for User-Agent ${userAgent ?? 'undefined'} ${
+      shouldIncludeAave ? 'including' : 'excluding'
+    } Aave`, async () => {
+      const server = getTestServer('hooks-api')
+      await request(server)
+        .get('/getPositions')
+        .set('user-agent', userAgent ?? '')
+        .query({
+          networkIds: [NetworkId['arbitrum-one']],
+          address: WALLET_ADDRESS,
+        })
+        .expect(200)
+
+      expect(getPositions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          appIds: shouldIncludeAave
+            ? expect.arrayContaining(['aave'])
+            : expect.not.arrayContaining(['aave']),
+        }),
+      )
+    })
+  }
 })
 
 describe('GET /getEarnPositions', () => {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,6 +10,7 @@ import Backend from 'i18next-fs-backend'
 import i18nextMiddleware from 'i18next-http-middleware'
 import path from 'path'
 import { z } from 'zod'
+import semver from 'semver'
 import { getConfig } from '../config'
 import { logger } from '../log'
 import { getBaseTokensInfo, getPositions } from '../runtime/getPositions'
@@ -141,8 +142,8 @@ function createApp() {
       const userAgent = req.header('user-agent')
       const valoraAppVersion = getValoraAppVersion(userAgent)
       const returnAavePositions = valoraAppVersion
-        ? valoraAppVersion >= '1.90.0'
-        : false
+        ? semver.gte(valoraAppVersion, '1.90.0')
+        : true
       const { address } = parsedRequest.query
       const networkIds = getNetworkIds(parsedRequest.query)
       const appIds = config.POSITION_IDS.filter((appId) =>


### PR DESCRIPTION
I was randomly reading the code and noticed the check to include/exclude Aave positions would fail once we hit v `1.100`. Which will be the next release.

This fixes it, and also defaults to including Aave for other Mobile Stack apps (any other User-Agent).
Which is what I think we want.