### PR TITLE
Capture RPC calls metrics

### DIFF
--- a/jest.e2e.config.js
+++ b/jest.e2e.config.js
@@ -14,4 +14,5 @@ module.exports = {
   },
   setupFiles: ['<rootDir>/scripts/loadProductionEnvVars.ts'],
   setupFilesAfterEnv: ['<rootDir>/jest.e2e.setup.js'],
+  globalTeardown: '<rootDir>/scripts/teardown.js'
 }

--- a/scripts/teardown.js
+++ b/scripts/teardown.js
@@ -1,0 +1,9 @@
+const fs = require('fs')
+
+const teardown = () => {
+  console.log('Tests finished! Running global cleanup...')
+  const data = fs.readFileSync('output.txt', 'utf8')
+  console.log(JSON.parse(data))
+}
+
+module.exports = teardown

--- a/scripts/teardown.js
+++ b/scripts/teardown.js
@@ -2,7 +2,7 @@ const fs = require('fs')
 
 const teardown = () => {
   console.log('Tests finished! Running global cleanup...')
-  const data = fs.readFileSync('output.txt', 'utf8')
+  const data = fs.readFileSync('.metrics.json', 'utf8')
   console.log(JSON.parse(data))
 }
 

--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -58,7 +58,7 @@ const hook: PositionsHook = {
       return []
     }
 
-    const client = getClient(networkId)
+    const client = getClient(networkId, 'aave')
 
     const [reservesData] = await client.readContract({
       address: aaveAddresses.uiPoolDataProvider,

--- a/src/apps/aave/shortcuts.ts
+++ b/src/apps/aave/shortcuts.ts
@@ -67,7 +67,7 @@ const hook: ShortcutsHook = {
           // amount in smallest unit
           const amountToSupply = parseUnits(tokens[0].amount, tokenDecimals)
 
-          const client = getClient(networkId)
+          const client = getClient(networkId, 'aave')
 
           const approvedAllowanceForSpender = await client.readContract({
             address: tokenAddress,
@@ -154,7 +154,7 @@ const hook: ShortcutsHook = {
             ? maxUint256
             : parseUnits(tokens[0].amount, tokenDecimals)
 
-          const client = getClient(networkId)
+          const client = getClient(networkId, 'aave')
 
           const underlyingAssetAddress = await client.readContract({
             address: tokenAddress,
@@ -190,7 +190,7 @@ const hook: ShortcutsHook = {
         async onTrigger({ networkId, address }) {
           const walletAddress = address as Address
 
-          const client = getClient(networkId)
+          const client = getClient(networkId, 'aave')
 
           // Get a/v/sToken for which we can claim rewards
           const reserveIncentiveData = await client.readContract({

--- a/src/apps/allbridge/positions.ts
+++ b/src/apps/allbridge/positions.ts
@@ -41,7 +41,7 @@ const hook: PositionsHook = {
       return []
     }
 
-    const client = getClient(networkId)
+    const client = getClient(networkId, 'allbridge')
 
     const [balances, rewards, totalSupplies, lpTokenDecimals] =
       await Promise.all([

--- a/src/apps/allbridge/shortcuts.ts
+++ b/src/apps/allbridge/shortcuts.ts
@@ -56,7 +56,7 @@ const hook: ShortcutsHook = {
           // amount in smallest unit
           const amountToSupply = parseUnits(tokens[0].amount, tokenDecimals)
 
-          const client = getClient(networkId)
+          const client = getClient(networkId, 'allbridge')
 
           const approvedAllowanceForSpender = await client.readContract({
             address: tokenAddress,

--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -312,7 +312,7 @@ const beefyBaseVaultsPositions = async ({
   tvls: BeefyPrices
   t: TFunction
 }) => {
-  const client = getClient(networkId)
+  const client = getClient(networkId, 'beefy')
 
   const userVaults: (BaseBeefyVault & { balance: bigint })[] = []
 
@@ -397,7 +397,7 @@ const beefyGovVaultsPositions = async (
   multicallAddress: Address,
   prices: BeefyPrices,
 ) => {
-  const client = getClient(networkId)
+  const client = getClient(networkId, 'beefy')
 
   const userVaults: (GovVault & { balance: bigint })[] = []
 

--- a/src/apps/beefy/shortcuts.ts
+++ b/src/apps/beefy/shortcuts.ts
@@ -55,7 +55,7 @@ const hook: ShortcutsHook = {
           // amount in smallest unit
           const amountToSupply = parseUnits(tokens[0].amount, tokenDecimals)
 
-          const client = getClient(networkId)
+          const client = getClient(networkId, 'beefy')
 
           const approvedAllowanceForSpender = await client.readContract({
             address: tokenAddress,

--- a/src/apps/compound/positions.ts
+++ b/src/apps/compound/positions.ts
@@ -75,7 +75,7 @@ const hook: PositionsHook = {
       return []
     }
 
-    const client = getClient(networkId)
+    const client = getClient(networkId, 'compound')
 
     const results = await client.readContract({
       code: compoundMulticallBytecode,

--- a/src/apps/curve/positions.ts
+++ b/src/apps/curve/positions.ts
@@ -94,7 +94,7 @@ export async function getPoolPositionDefinitions(
   let consideredPools = pools
   if (address) {
     // call balanceOf to check if user has balance on a pool
-    const client = getClient(networkId)
+    const client = getClient(networkId, 'curve')
     const result = await client.multicall({
       contracts: pools.map(
         (pool) =>

--- a/src/apps/hedgey/positions.ts
+++ b/src/apps/hedgey/positions.ts
@@ -27,7 +27,7 @@ const hook: PositionsHook = {
     }
     const planNfts = await getHedgeyPlanNfts({ address })
     const now = BigInt(Math.floor(new Date().getTime() / 1000))
-    const client = getClient(networkId)
+    const client = getClient(networkId, 'hedgey')
     const positions: ContractPositionDefinition[] = await Promise.all(
       planNfts.map(async (planNft) => {
         const tokenVestingPlanContract = {

--- a/src/apps/mento/positions.ts
+++ b/src/apps/mento/positions.ts
@@ -25,7 +25,7 @@ async function getVeMentoPositionDefinition(
     return undefined
   }
 
-  const client = getClient(networkId)
+  const client = getClient(networkId, 'mento')
   const [mentoTokenAddress, decimals, locked, balance] = await client.multicall(
     {
       contracts: [

--- a/src/apps/stake-dao/positions.ts
+++ b/src/apps/stake-dao/positions.ts
@@ -51,7 +51,7 @@ async function getVaultPositionDefinitions(
   networkId: NetworkId,
   address: Address | undefined,
 ): Promise<PositionDefinition[]> {
-  const client = getClient(networkId)
+  const client = getClient(networkId, 'stake-dao')
 
   const vaultAddresses = SD_VAULT_ADDRESSES_BY_NETWORK_ID[networkId]
   const vaultsData = await client.multicall({

--- a/src/apps/uniswap/positions.ts
+++ b/src/apps/uniswap/positions.ts
@@ -1,4 +1,4 @@
-import { Address } from 'viem'
+import { Address, PublicClient } from 'viem'
 import { getClient } from '../../runtime/client'
 import { getTokenId } from '../../runtime/getTokenId'
 import { NetworkId } from '../../types/networkId'
@@ -75,8 +75,11 @@ export async function getUniswapV3PositionDefinitions(
   nftPositions: Address,
   factory: Address,
   imageUrl: string = 'https://raw.githubusercontent.com/valora-inc/dapp-list/ab12ab234b4a6e01eff599c6bd0b7d5b44d6f39d/assets/uniswap.png',
+  client?: PublicClient,
 ): Promise<ContractPositionDefinition[]> {
-  const client = getClient(networkId)
+  if (!client) {
+    client = getClient(networkId, 'uniswap')
+  }
   const userPools = await client.readContract({
     abi: userPositionsAbi,
     address: userPositionsMulticall,

--- a/src/apps/walletconnect/positions.ts
+++ b/src/apps/walletconnect/positions.ts
@@ -34,7 +34,7 @@ async function getStakedWctPositionDefinition(
     return undefined
   }
 
-  const client = getClient(networkId)
+  const client = getClient(networkId, 'walletconnect')
   const locks = await client.readContract({
     address: wctStakingConfig.stakingAddress,
     abi: stakingAbi,

--- a/src/metrics/index.ts
+++ b/src/metrics/index.ts
@@ -1,0 +1,99 @@
+import fs from 'fs'
+
+export class Metrics {
+  networks: {
+    'celo-mainnet': number
+    'ethereum-mainnet': number
+    'arbitrum-one': number
+    'op-mainnet': number
+    'celo-alfajores': number
+    'ethereum-sepolia': number
+    'arbitrum-sepolia': number
+    'op-sepolia': number
+    'polygon-pos-mainnet': number
+    'polygon-pos-amoy': number
+    'base-mainnet': number
+    'base-sepolia': number
+  }
+  apps: {
+    aave: number
+    allbridge: number
+    beefy: number
+    compound: number
+    curve: number
+    gooddollar: number
+    halofi: number
+    hedgey: number
+    'locked-celo': number
+    mento: number
+    moola: number
+    'stake-dao': number
+    ubeswap: number
+    uniswap: number
+    walletconnect: number
+  }
+  appNames: string[]
+  networkNames: string[]
+
+  constructor() {
+    this.networks = {
+      'celo-mainnet': 0,
+      'ethereum-mainnet': 0,
+      'arbitrum-one': 0,
+      'op-mainnet': 0,
+      'celo-alfajores': 0,
+      'ethereum-sepolia': 0,
+      'arbitrum-sepolia': 0,
+      'op-sepolia': 0,
+      'polygon-pos-mainnet': 0,
+      'polygon-pos-amoy': 0,
+      'base-mainnet': 0,
+      'base-sepolia': 0,
+    }
+    this.apps = {
+      aave: 0,
+      allbridge: 0,
+      beefy: 0,
+      compound: 0,
+      curve: 0,
+      gooddollar: 0,
+      halofi: 0,
+      hedgey: 0,
+      'locked-celo': 0,
+      mento: 0,
+      moola: 0,
+      'stake-dao': 0,
+      ubeswap: 0,
+      uniswap: 0,
+      walletconnect: 0,
+    }
+    this.appNames = Object.keys(this.apps)
+    this.networkNames = Object.keys(this.networks)
+  }
+
+  updateApp(appName: string) {
+    if (appName && this.appNames.includes(appName)) {
+      // @ts-expect-error Only app names are allowed
+      this.apps[appName] += 1
+    }
+  }
+
+  updateNetwork(networkId: string) {
+    if (networkId && this.networkNames.includes(networkId)) {
+      // @ts-expect-error Only app names are allowed
+      this.networks[networkId] += 1
+    }
+  }
+
+  save() {
+    fs.writeFileSync(
+      '.metrics.json',
+      JSON.stringify({
+        apps: this.apps,
+        networks: this.networks,
+      }),
+    )
+  }
+}
+
+export const metrics = new Metrics()

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -27,7 +27,7 @@ import { logger } from '../log'
 
 const MULTICALL_ADDRESS = '0XCA11BDE05977B3631167028862BE2A173976CA11'
 
-export const networkIdToViemChain: Record<NetworkId, Chain> = {
+const networkIdToViemChain: Record<NetworkId, Chain> = {
   [NetworkId['celo-mainnet']]: celo,
   [NetworkId['ethereum-mainnet']]: mainnet,
   [NetworkId['arbitrum-one']]: arbitrum,

--- a/src/runtime/client.ts
+++ b/src/runtime/client.ts
@@ -47,6 +47,7 @@ const clientsCache = new Map<
 
 export function getClient(
   networkId: NetworkId,
+  appName?: string,
 ): PublicClient<ReturnType<typeof http>, Chain> {
   let client = clientsCache.get(networkId)
   if (client) {
@@ -61,12 +62,13 @@ export function getClient(
     return http(url, {
       onFetchRequest: async (request) => {
         const body = await request.json()
+        let message= appName ? `[${appName}]: ` : ''
         if (body.params[0].to === MULTICALL_ADDRESS) {
-          console.log('Multicall fetch')
+          message += `Multicall from client`
         } else {
-          console.log('Normal fetch')
+          message += `Call to ${body.params[0].to}`
         }
-        console.log(body.params[0].data)
+        console.log(message)
         // logger.trace({ msg: 'rpc.http: request', data: await request.json() })
       },
       ...config,


### PR DESCRIPTION
Closes: #597 

RPC call data is captured by a [custom transport](https://viem.sh/docs/clients/transports/custom).
Logs have the following format:
`<networkId>: [<appName>] Call to <address>(multicall optional)`
Example log:
`ethereum-mainnet: [curve] Call to 0xca11bde05977b3631167028862be2a173976ca11(multicall)`

A metrics object captures  network and  app specific metrics.