### PR TITLE
refactor: remove `id` and `description` from `AppInfo`

### DIFF
--- a/src/apps/aave/positions.ts
+++ b/src/apps/aave/positions.ts
@@ -47,9 +47,7 @@ function getApyFromRayApr(apr: bigint) {
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'aave',
       name: 'Aave',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId, address, t }) {

--- a/src/apps/allbridge/positions.ts
+++ b/src/apps/allbridge/positions.ts
@@ -29,9 +29,7 @@ import { getPositionId } from '../../runtime/getPositionId'
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'allbridge',
       name: 'Allbridge',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId, address, t }) {

--- a/src/apps/beefy/positions.test.ts
+++ b/src/apps/beefy/positions.test.ts
@@ -215,9 +215,7 @@ describe('hook', () => {
   })
   it('should return the correct hook info', () => {
     expect(hook.getInfo()).toEqual({
-      id: 'beefy',
       name: 'Beefy',
-      description: 'Beefy vaults',
     })
   })
   it('should return expected positions with balances when getPositionDefinitions is called with supported networkId and address', async () => {

--- a/src/apps/beefy/positions.ts
+++ b/src/apps/beefy/positions.ts
@@ -483,9 +483,7 @@ const beefyGovVaultsPositions = async (
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'beefy',
       name: 'Beefy',
-      description: 'Beefy vaults',
     }
   },
   async getPositionDefinitions({ networkId, address, t }) {

--- a/src/apps/compound/positions.ts
+++ b/src/apps/compound/positions.ts
@@ -64,9 +64,7 @@ const MARKETS: { networkId: NetworkId; address: Address }[] = [
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'compound',
       name: 'Compound',
-      description: 'Compound markets',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/curve/positions.ts
+++ b/src/apps/curve/positions.ts
@@ -190,9 +190,7 @@ async function getPoolPositionDefinition(
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'curve',
       name: 'Curve',
-      description: 'Curve pools',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/example/positions.ts
+++ b/src/apps/example/positions.ts
@@ -9,12 +9,11 @@ const CUSD_ADDRESS: Address = '0x765de816845861e75a25fca122bb6898b8b1282a'
 export const DEFAULT_IMG_URL =
   'https://raw.githubusercontent.com/valora-inc/address-metadata/main/assets/tokens/CELO.png'
 
+// Example position for developers
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'example',
       name: 'Example',
-      description: 'Example position for developers',
     }
   },
 

--- a/src/apps/gooddollar/positions.ts
+++ b/src/apps/gooddollar/positions.ts
@@ -29,9 +29,7 @@ const client = createPublicClient({
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'gooddollar',
       name: 'GoodDollar',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/halofi/positions.ts
+++ b/src/apps/halofi/positions.ts
@@ -13,10 +13,7 @@ import { getTokenId } from '../../runtime/getTokenId'
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'halofi',
       name: 'HaloFi',
-      description:
-        'Grow wealth with crypto, earn rewards, badges & more. We make personal finance fun.',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/hedgey/positions.ts
+++ b/src/apps/hedgey/positions.ts
@@ -14,9 +14,7 @@ import { getClient } from '../../runtime/client'
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'hedgey',
       name: 'Hedgey',
-      description: 'Hedgey vesting plans',
     }
   },
 

--- a/src/apps/locked-celo/positions.ts
+++ b/src/apps/locked-celo/positions.ts
@@ -40,9 +40,7 @@ function zip<A, B>(as: readonly A[], bs: readonly B[]) {
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'locked-celo',
       name: 'Locked CELO',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/mento/positions.ts
+++ b/src/apps/mento/positions.ts
@@ -95,9 +95,7 @@ async function getVeMentoPositionDefinition(
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'mento',
       name: 'Mento',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/moola/positions.ts
+++ b/src/apps/moola/positions.ts
@@ -37,9 +37,7 @@ function getAppTokenPositionDefinition(
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'moola',
       name: 'Moola',
-      description: 'Moola debt tokens',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/stake-dao/positions.ts
+++ b/src/apps/stake-dao/positions.ts
@@ -158,9 +158,7 @@ async function getVaultPositionDefinitions(
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'stake-dao',
       name: 'Stake DAO',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/ubeswap/positions.ts
+++ b/src/apps/ubeswap/positions.ts
@@ -326,9 +326,7 @@ async function getV3Positions(networkId: NetworkId, address: Address) {
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'ubeswap',
       name: 'Ubeswap',
-      description: 'Decentralized exchange on Celo',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/uniswap/positions.ts
+++ b/src/apps/uniswap/positions.ts
@@ -150,9 +150,7 @@ export async function getUniswapV3PositionDefinitions(
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'uniswap',
       name: 'Uniswap',
-      description: 'Uniswap pools',
     }
   },
   async getPositionDefinitions({ networkId, address }) {

--- a/src/apps/walletconnect/positions.ts
+++ b/src/apps/walletconnect/positions.ts
@@ -96,9 +96,7 @@ async function getStakedWctPositionDefinition(
 const hook: PositionsHook = {
   getInfo() {
     return {
-      id: 'walletconnect',
       name: 'WalletConnect',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId, address, t }) {

--- a/src/runtime/getPositions.test.ts
+++ b/src/runtime/getPositions.test.ts
@@ -40,9 +40,7 @@ for (const [tokenId, tokenInfo] of Object.entries(mockTokensInfo)) {
 const lockedCeloTestHook: PositionsHook = {
   getInfo() {
     return {
-      id: 'locked-celo-test',
       name: 'Locked CELO Test',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId }) {
@@ -72,9 +70,7 @@ const lockedCeloTestHook: PositionsHook = {
 const failingTestHook: PositionsHook = {
   getInfo() {
     return {
-      id: 'failing-hook',
       name: 'Failing Hook',
-      description: '',
     }
   },
   async getPositionDefinitions({ networkId: _networkId }) {
@@ -115,9 +111,7 @@ describe(getPositions, () => {
     const testHook: PositionsHook = {
       getInfo() {
         return {
-          id: 'test-hook',
           name: 'Test Hook',
-          description: '',
         }
       },
       async getPositionDefinitions({ networkId }) {
@@ -167,9 +161,7 @@ describe(getPositions, () => {
     const testHook: PositionsHook = {
       getInfo() {
         return {
-          id: 'beefy-price-escape',
           name: 'Beefy Price Escape',
-          description: 'Beefy with price escape hatch for underlying tokens',
         }
       },
 
@@ -260,9 +252,7 @@ describe(getPositions, () => {
     const testHook: PositionsHook = {
       getInfo() {
         return {
-          id: 'test-hook',
           name: 'Test Hook',
-          description: '',
         }
       },
       async getPositionDefinitions({ networkId }) {

--- a/src/types/positions.ts
+++ b/src/types/positions.ts
@@ -172,9 +172,7 @@ export type PositionDefinition =
 // Generic info about the app
 // Note: this could be used for dapp listing too
 export interface AppInfo {
-  id: string // Example: ubeswap
   name: string // Example: Ubeswap
-  description: string // Example: Decentralized exchange on Celo
 }
 
 export interface AbstractPosition {


### PR DESCRIPTION
`description` is not used and the `id` is determined from the folder name. So removing to avoid confusion.

Addresses https://github.com/mobilestack-xyz/hooks/pull/692#discussion_r1883666876