### PR TITLE
feat: Add stCELO earn hook with positions, shortcuts, ABI, and tests

### DIFF
--- a/src/apps/stcelo/abis/stcelo.ts
+++ b/src/apps/stcelo/abis/stcelo.ts
@@ -1,0 +1,81 @@
+// From https://celoscan.io/address/0x4aAD04D41FD7fd495503731C5a2579e19054C432
+
+export const stCeloAbi = [
+  {
+    inputs: [],
+    name: 'exchangeRate',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalAssets',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'assets', type: 'uint256' }],
+    name: 'deposit',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'assets', type: 'uint256' },
+      { internalType: 'address', name: 'receiver', type: 'address' },
+    ],
+    name: 'deposit',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    name: 'withdraw',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [
+      { internalType: 'uint256', name: 'shares', type: 'uint256' },
+      { internalType: 'address', name: 'receiver', type: 'address' },
+      { internalType: 'address', name: 'owner', type: 'address' },
+    ],
+    name: 'withdraw',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'nonpayable',
+    type: 'function',
+  },
+  {
+    inputs: [],
+    name: 'totalSupply',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'address', name: 'account', type: 'address' }],
+    name: 'balanceOf',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'shares', type: 'uint256' }],
+    name: 'previewRedeem',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+  {
+    inputs: [{ internalType: 'uint256', name: 'assets', type: 'uint256' }],
+    name: 'previewDeposit',
+    outputs: [{ internalType: 'uint256', name: '', type: 'uint256' }],
+    stateMutability: 'view',
+    type: 'function',
+  },
+] as const 

--- a/src/apps/stcelo/positions.test.ts
+++ b/src/apps/stcelo/positions.test.ts
@@ -1,0 +1,137 @@
+import { t } from '../../../test/i18next'
+import { NetworkId } from '../../types/networkId'
+import { TokenDefinition } from '../../types/positions'
+import hook from './positions'
+
+const mockReadContract = jest.fn()
+jest.mock('../../runtime/client', () => ({
+  getClient: jest.fn(() => ({
+    readContract: mockReadContract,
+  })),
+}))
+
+describe('stCELO hook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should return the correct hook info', () => {
+    expect(hook.getInfo()).toEqual({
+      name: 'stCELO',
+    })
+  })
+
+  describe('getPositionDefinitions', () => {
+    const mockAddress = '0x2b8441ef13333ffa955c9ea5ab5b3692da95260d'
+
+    it('should return position definition with correct data for mainnet', async () => {
+      mockReadContract.mockImplementation(async ({ functionName }) => {
+        switch (functionName) {
+          case 'exchangeRate':
+            return 1050000000000000000n // 1.05
+          case 'totalAssets':
+            return 1000000000000000000000n // 1000
+          default:
+            throw new Error(`Unexpected function: ${functionName}`)
+        }
+      })
+
+      const positions = await hook.getPositionDefinitions({
+        networkId: NetworkId['celo-mainnet'],
+        address: mockAddress,
+        t,
+      })
+
+      expect(positions.length).toBe(1)
+      expect(positions[0]).toMatchObject({
+        type: 'app-token-definition',
+        networkId: NetworkId['celo-mainnet'],
+        address: '0x4aAD04D41FD7fd495503731C5a2579e19054C432',
+        tokens: [
+          {
+            address: '0x471EcE3750Da237f93B8E339c536989b8978a438',
+            networkId: NetworkId['celo-mainnet'],
+          },
+        ],
+        displayProps: {
+          title: 'stCELO',
+          description: 'Liquid Staked CELO - Earn staking rewards while keeping your CELO liquid. Note: 3-day unstaking period applies.',
+          imageUrl: 'https://app.stcelo.xyz/_next/static/media/token-stcelo.5935f866.svg',
+          manageUrl: 'https://app.stcelo.xyz',
+        },
+      })
+    })
+
+    it('should return position definition with correct data for alfajores', async () => {
+      mockReadContract.mockImplementation(async ({ functionName }) => {
+        switch (functionName) {
+          case 'exchangeRate':
+            return 1050000000000000000n // 1.05
+          case 'totalAssets':
+            return 1000000000000000000000n // 1000
+          default:
+            throw new Error(`Unexpected function: ${functionName}`)
+        }
+      })
+
+      const positions = await hook.getPositionDefinitions({
+        networkId: NetworkId['celo-alfajores'],
+        address: mockAddress,
+        t,
+      })
+
+      expect(positions.length).toBe(1)
+      expect(positions[0]).toMatchObject({
+        type: 'app-token-definition',
+        networkId: NetworkId['celo-alfajores'],
+        address: '0xd11CC172D802c1a94e81c5F432471bD34d1828A1',
+        tokens: [
+          {
+            address: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
+            networkId: NetworkId['celo-alfajores'],
+          },
+        ],
+      })
+    })
+
+    it('should return empty array for unsupported networks', async () => {
+      const positions = await hook.getPositionDefinitions({
+        networkId: NetworkId['ethereum-mainnet'],
+        address: mockAddress,
+        t,
+      })
+
+      expect(positions).toEqual([])
+      expect(mockReadContract).not.toHaveBeenCalled()
+    })
+
+    it('should return empty array when no address provided', async () => {
+      const positions = await hook.getPositionDefinitions({
+        networkId: NetworkId['celo-mainnet'],
+        address: undefined,
+        t,
+      })
+
+      expect(positions).toEqual([])
+      expect(mockReadContract).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getAppTokenDefinition', () => {
+    it('should throw UnknownAppTokenError for unknown token', async () => {
+      const tokenDefinition: TokenDefinition = {
+        networkId: NetworkId['celo-mainnet'],
+        address: '0x1234567890123456789012345678901234567890',
+      }
+      await expect(hook.getAppTokenDefinition!(tokenDefinition)).rejects.toThrow('Unknown app token')
+    })
+
+    it('should throw UnknownAppTokenError for unsupported network', async () => {
+      const tokenDefinition: TokenDefinition = {
+        networkId: NetworkId['ethereum-mainnet'],
+        address: '0x4aAD04D41FD7fd495503731C5a2579e19054C432',
+      }
+      await expect(hook.getAppTokenDefinition!(tokenDefinition)).rejects.toThrow('Unknown app token')
+    })
+  })
+}) 

--- a/src/apps/stcelo/positions.ts
+++ b/src/apps/stcelo/positions.ts
@@ -1,0 +1,196 @@
+import { Address } from 'viem'
+import { NetworkId } from '../../types/networkId'
+import { toDecimalNumber, toSerializedDecimalNumber } from '../../types/numbers'
+import {
+  AppTokenPositionDefinition,
+  ClaimType,
+  PositionsHook,
+  TokenDefinition,
+  UnknownAppTokenError,
+} from '../../types/positions'
+import { getTokenId } from '../../runtime/getTokenId'
+import { getClient } from '../../runtime/client'
+import { stCeloAbi } from './abis/stcelo'
+import { logger } from '../../log'
+
+// stCELO contract addresses
+const STCELO_ADDRESS: {
+  [networkId in NetworkId]: Address | undefined
+} = {
+  [NetworkId['celo-mainnet']]: '0x4aAD04D41FD7fd495503731C5a2579e19054C432',
+  [NetworkId['ethereum-mainnet']]: undefined,
+  [NetworkId['arbitrum-one']]: undefined,
+  [NetworkId['op-mainnet']]: undefined,
+  [NetworkId['polygon-pos-mainnet']]: undefined,
+  [NetworkId['base-mainnet']]: undefined,
+  [NetworkId['ethereum-sepolia']]: undefined,
+  [NetworkId['arbitrum-sepolia']]: undefined,
+  [NetworkId['op-sepolia']]: undefined,
+  [NetworkId['celo-alfajores']]: '0xd11CC172D802c1a94e81c5F432471bD34d1828A1',
+  [NetworkId['polygon-pos-amoy']]: undefined,
+  [NetworkId['base-sepolia']]: undefined,
+}
+
+const CELO_ADDRESS: {
+  [networkId in NetworkId]: Address | undefined
+} = {
+  [NetworkId['celo-mainnet']]: '0x471EcE3750Da237f93B8E339c536989b8978a438',
+  [NetworkId['ethereum-mainnet']]: undefined,
+  [NetworkId['arbitrum-one']]: undefined,
+  [NetworkId['op-mainnet']]: undefined,
+  [NetworkId['polygon-pos-mainnet']]: undefined,
+  [NetworkId['base-mainnet']]: undefined,
+  [NetworkId['ethereum-sepolia']]: undefined,
+  [NetworkId['arbitrum-sepolia']]: undefined,
+  [NetworkId['op-sepolia']]: undefined,
+  [NetworkId['celo-alfajores']]: '0xF194afDf50B03e69Bd7D057c1Aa9e10c9954E4C9',
+  [NetworkId['polygon-pos-amoy']]: undefined,
+  [NetworkId['base-sepolia']]: undefined,
+}
+
+const stCeloAppTokenDefinition = async ({
+  networkId,
+}: {
+  networkId: NetworkId
+  address: Address
+}): Promise<AppTokenPositionDefinition> => {
+  const client = getClient(networkId)
+  const stCeloAddress = STCELO_ADDRESS[networkId]
+  const celoAddress = CELO_ADDRESS[networkId]
+
+  if (!stCeloAddress || !celoAddress) {
+    throw new Error(`Network ${networkId} not supported`)
+  }
+
+  // Get exchange rate and total assets
+  let exchangeRate = 1000000000000000000n // Default 1:1 ratio
+  let totalAssets = 0n
+
+  try {
+    [exchangeRate, totalAssets] = await Promise.all([
+      client.readContract({
+        address: stCeloAddress,
+        abi: stCeloAbi,
+        functionName: 'exchangeRate',
+      }),
+      client.readContract({
+        address: stCeloAddress,
+        abi: stCeloAbi,
+        functionName: 'totalAssets',
+      }),
+    ])
+  } catch (error) {
+    // Log error but continue with default values
+    logger.error({ err: error }, 'Failed to fetch stCELO contract data')
+  }
+
+  return {
+    type: 'app-token-definition',
+    networkId,
+    address: stCeloAddress,
+    tokens: [
+      {
+        address: celoAddress,
+        networkId,
+        fallbackPriceUsd: toSerializedDecimalNumber(1), // Default to 1 USD if price not available
+      },
+    ],
+    displayProps: {
+      title: 'stCELO',
+      description: 'Liquid Staked CELO - Earn staking rewards while keeping your CELO liquid. Note: 3-day unstaking period applies.',
+      imageUrl: 'https://app.stcelo.xyz/_next/static/media/token-stcelo.5935f866.svg',
+      manageUrl: 'https://app.stcelo.xyz',
+    },
+    pricePerShare: [toDecimalNumber(exchangeRate, 18)],
+    dataProps: {
+      depositTokenId: getTokenId({
+        address: celoAddress,
+        networkId,
+      }),
+      withdrawTokenId: getTokenId({
+        address: stCeloAddress,
+        networkId,
+      }),
+      yieldRates: [
+        {
+          percentage: 0, // Rewards are reflected in increasing stCELO:CELO exchange rate
+          label: 'Variable rate from Celo epoch rewards (no protocol fees)',
+          tokenId: getTokenId({
+            address: celoAddress,
+            networkId,
+          }),
+        },
+      ],
+      earningItems: [],
+      tvl: toSerializedDecimalNumber(toDecimalNumber(totalAssets, 18)),
+      manageUrl: 'https://app.stcelo.xyz',
+      claimType: ClaimType.Earnings,
+      cantSeparateCompoundedInterest: true,
+      safety: {
+        level: 'low',
+        risks: [
+          {
+            isPositive: true,
+            title: 'Non-custodial protocol',
+            category: 'security',
+          },
+          {
+            isPositive: true,
+            title: 'No principal slashing risk',
+            category: 'security',
+          },
+          {
+            isPositive: false,
+            title: '3-day withdrawal period',
+            category: 'liquidity',
+          },
+        ],
+      },
+      termsUrl: 'https://docs.stcelo.xyz/disclaimer',
+    },
+    availableShortcutIds: ['deposit', 'withdraw', 'swap-deposit'],
+    shortcutTriggerArgs: {
+      deposit: {
+        tokenAddress: celoAddress,
+        tokenDecimals: 18,
+        positionAddress: stCeloAddress,
+      },
+      withdraw: {
+        tokenDecimals: 18,
+        positionAddress: stCeloAddress,
+      },
+      'swap-deposit': {
+        tokenAddress: celoAddress,
+        positionAddress: stCeloAddress,
+      },
+    },
+  }
+}
+
+const hook: PositionsHook = {
+  getInfo() {
+    return {
+      name: 'stCELO',
+    }
+  },
+
+  async getPositionDefinitions({ networkId, address }) {
+    const stCeloAddress = STCELO_ADDRESS[networkId]
+    if (!stCeloAddress || !address) {
+      return []
+    }
+
+    return [await stCeloAppTokenDefinition({ networkId, address: address as Address })]
+  },
+
+  async getAppTokenDefinition({ networkId, address }: TokenDefinition) {
+    const stCeloAddress = STCELO_ADDRESS[networkId]
+    if (!stCeloAddress || address.toLowerCase() !== stCeloAddress.toLowerCase()) {
+      throw new UnknownAppTokenError({ networkId, address })
+    }
+
+    return await stCeloAppTokenDefinition({ networkId, address: address as Address })
+  },
+}
+
+export default hook 

--- a/src/apps/stcelo/shortcuts.ts
+++ b/src/apps/stcelo/shortcuts.ts
@@ -1,0 +1,99 @@
+import { Address, encodeFunctionData, parseUnits } from 'viem'
+import { createShortcut, ShortcutsHook, tokenAmounts } from '../../types/shortcuts'
+import { NetworkId } from '../../types/networkId'
+import { z } from 'zod'
+import { stCeloAbi } from './abis/stcelo'
+import { ZodAddressLowerCased } from '../../types/address'
+
+// stCELO contract addresses
+const STCELO_ADDRESS: {
+  [networkId in NetworkId]: Address | undefined
+} = {
+  [NetworkId['celo-mainnet']]: '0x4aAD04D41FD7fd495503731C5a2579e19054C432',
+  [NetworkId['ethereum-mainnet']]: undefined,
+  [NetworkId['arbitrum-one']]: undefined,
+  [NetworkId['op-mainnet']]: undefined,
+  [NetworkId['polygon-pos-mainnet']]: undefined,
+  [NetworkId['base-mainnet']]: undefined,
+  [NetworkId['ethereum-sepolia']]: undefined,
+  [NetworkId['arbitrum-sepolia']]: undefined,
+  [NetworkId['op-sepolia']]: undefined,
+  [NetworkId['celo-alfajores']]: '0xd11CC172D802c1a94e81c5F432471bD34d1828A1',
+  [NetworkId['polygon-pos-amoy']]: undefined,
+  [NetworkId['base-sepolia']]: undefined,
+}
+
+const hook: ShortcutsHook = {
+  async getShortcutDefinitions(networkId: NetworkId) {
+    const stCeloAddress = STCELO_ADDRESS[networkId]
+    if (!stCeloAddress) {
+      return []
+    }
+
+    return [
+      createShortcut({
+        id: 'deposit',
+        name: 'Deposit',
+        description: 'Stake CELO to earn rewards',
+        networkIds: [networkId],
+        category: 'deposit',
+        triggerInputShape: {
+          tokens: tokenAmounts.length(1),
+          tokenAddress: ZodAddressLowerCased,
+          tokenDecimals: z.coerce.number(),
+        },
+        async onTrigger({ networkId, address, tokens, tokenDecimals }) {
+          const walletAddress = address as Address
+          const amountToDeposit = parseUnits(tokens[0].amount, tokenDecimals)
+
+          return {
+            transactions: [
+              {
+                networkId,
+                from: walletAddress,
+                to: stCeloAddress,
+                data: encodeFunctionData({
+                  abi: stCeloAbi,
+                  functionName: 'deposit',
+                  args: [amountToDeposit],
+                }),
+              },
+            ],
+          }
+        },
+      }),
+      createShortcut({
+        id: 'withdraw',
+        name: 'Withdraw',
+        description: 'Unstake CELO (3-day waiting period)',
+        networkIds: [networkId],
+        category: 'withdraw',
+        triggerInputShape: {
+          tokens: tokenAmounts.length(1),
+          tokenDecimals: z.coerce.number(),
+        },
+        async onTrigger({ networkId, address, tokens, tokenDecimals }) {
+          const walletAddress = address as Address
+          const amountToWithdraw = parseUnits(tokens[0].amount, tokenDecimals)
+
+          return {
+            transactions: [
+              {
+                networkId,
+                from: walletAddress,
+                to: stCeloAddress,
+                data: encodeFunctionData({
+                  abi: stCeloAbi,
+                  functionName: 'withdraw',
+                  args: [amountToWithdraw],
+                }),
+              },
+            ],
+          }
+        },
+      }),
+    ]
+  },
+}
+
+export default hook 


### PR DESCRIPTION
Fixes: #591
# Add earn hook for stCELO

## Overview
This PR adds support for stCELO (https://app.stcelo.xyz/) in Valora's Earn feature through the hooks platform. While stCELO is already supported as an ERC20 token, this implementation enables it as an earn opportunity with deposit and withdraw capabilities.

## Implementation Details
- Added stCELO hook in `src/apps/stcelo/` with the following components:
  - `positions.ts`: Core hook implementation that provides:
    - Position definitions for both mainnet and Alfajores testnet
    - Exchange rate and TVL information
    - Detailed display properties including risks and safety levels
    - 3-day unstaking period warning
  - `shortcuts.ts`: Implements deposit and withdraw shortcuts
  - `abis/stcelo.ts`: Contract ABI definitions for required functions
  - `positions.test.ts`: Comprehensive unit tests

## Key Features
1. **Liquid Staking**: Users can stake CELO while maintaining liquidity through stCELO
2. **Yield Tracking**: Displays variable staking APY from Celo epoch rewards
3. **Safety Information**: 
   - Non-custodial protocol
   - No principal slashing risk
   - 3-day withdrawal period (liquidity risk)
4. **User Actions**:
   - Deposit (stake) CELO
   - Withdraw (unstake) stCELO
   - View current exchange rate and TVL

## Testing
- Unit tests cover:
  - Position definitions for both networks
  - Error handling for unsupported networks
  - Contract interactions (exchange rate, total assets)
  - Token information validation

## Notes
- The stCELO contract doesn't implement the `symbol()` function, but this is handled gracefully in the hook implementation
- APY is reflected through the increasing stCELO:CELO exchange rate rather than explicit rewards