### PR TITLE
feat: add base to supported earn networks

### DIFF
--- a/src/api/production.yaml
+++ b/src/api/production.yaml
@@ -3,6 +3,6 @@ GOOGLE_CLOUD_PROJECT: celo-mobile-mainnet
 POSITION_IDS: 'curve,beefy,gooddollar,hedgey,locked-celo,mento,moola,stake-dao,ubeswap,uniswap,allbridge,aave,walletconnect,somm'
 SHORTCUT_IDS: 'gooddollar,hedgey,ubeswap,allbridge,aave,somm'
 GET_TOKENS_INFO_URL: 'https://api.mainnet.valora.xyz/getTokensInfoWithPrices'
-EARN_SUPPORTED_NETWORK_IDS: 'arbitrum-one,celo-mainnet,op-mainnet'
+EARN_SUPPORTED_NETWORK_IDS: 'arbitrum-one,celo-mainnet,op-mainnet,base-mainnet'
 SIMULATE_TRANSACTIONS_URL: 'https://api.mainnet.valora.xyz/simulateTransactions'
 GET_SWAP_QUOTE_URL: 'https://api.mainnet.valora.xyz/getSwapQuote'


### PR DESCRIPTION
Apps still need to opt-in on a per pool basis via the [statsig earn config](https://console.statsig.com/4plizaPmWwPL21ASV4QAO0/dynamic_configs/earn_config), so this won't afffect anything live right now. It will allow my FaF project to use base pools :) 